### PR TITLE
Typo for inner product?

### DIFF
--- a/lectures/splines_rkhs/splines_rkhs.tex
+++ b/lectures/splines_rkhs/splines_rkhs.tex
@@ -1200,7 +1200,7 @@ three properties, which must hold for all $f,g,h \in \cH$ and all $a,b \in \R$:
 \begin{enumerate}
 \item $\langle af + bg, h \rangle_\cH = a \langle f,h \rangle_\cH + b \langle
   g,h \rangle_\cH$;
-\item $\langle f,g \rangle_\cH = \langle g,h \rangle_\cH$;
+\item $\langle f,g \rangle_\cH = \langle g,f \rangle_\cH$;
 \item $\langle f,f \rangle_\cH \geq 0$ with equality iff $f=0$. 
 \end{enumerate}
 We can always define a norm based on this inner product, denoted


### PR DESCRIPTION
Inner product symmetric should be <f, g> = <g, f> instead of <g, h>?