### PR TITLE
Missing n in 2c)

### DIFF
--- a/homeworks/homework2/homework2.tex
+++ b/homeworks/homework2/homework2.tex
@@ -145,7 +145,7 @@ proxy $\sigma^2$. (We assume nothing about their dependence structure.)
 \item Prove that for any $\lambda \in \R$,
   \marginpar{\small [2 pts]}
   \[
-  \P \Big(\max_{i=1,\dots,n} \, X_i \geq \lambda \Big) \leq e^{-\lambda^2 /
+  \P \Big(\max_{i=1,\dots,n} \, X_i \geq \lambda \Big) \leq ne^{-\lambda^2 /
     (2\sigma^2)}.  
   \]
 


### PR DESCRIPTION
Max of sG is stochastically larger than any one,. Nor would rescaling hold in d).