### PR TITLE
3 a): Should be 8 M \sigma

### DIFF
--- a/homeworks/homework2/homework2.tex
+++ b/homeworks/homework2/homework2.tex
@@ -192,7 +192,7 @@ where $Y = (y_1,\dots,y_n) \in \R^n$ is the response vector, $X \in \R^{n \times
   satisfying 
   \marginpar{\small [3 pts]}
   \[
-  \frac{1}{n} \E \|X\hbeta - X\beta_0\|_2^2 \leq 4M \sigma \|\beta_0\|_1
+  \frac{1}{n} \E \|X\hbeta - X\beta_0\|_2^2 \leq 8M \sigma \|\beta_0\|_1
   \sqrt{\frac{2 \log(2d)}{n}},  
   \]
   where the expectation is taken over the training data $(x_i,y_i)$,


### PR DESCRIPTION
The whole process is indeed similar to computation leading up to eq (16) in LASSO notes. However, the scaling is off by a factor of 2. The result in eq (16) is obtained by sG var with variance proxy n \sigma^{2}. Here we have sG with variance proxy 4 M^{2} n \sigma^{2}. Taking the square root and we are off by a factor of 2. 