### PR TITLE
Correct minor typo

### DIFF
--- a/lectures/resolvents/resolvents.tex
+++ b/lectures/resolvents/resolvents.tex
@@ -162,7 +162,7 @@ and $\gamma_n$
 that will be useful for our purposes. 
 
 A helpful corollary of \Cref{lem:basic-ridge-resolvent-deterministic-equivalent}
-is the following result that considers the``scaled'' ridge resolvent.
+is the following result that considers the ``scaled'' ridge resolvent.
 The reason why such scaling helps is because
 in the limit as $\lambda \to 0^+$,
 the ridge resolvent itself may blow up,


### PR DESCRIPTION
The pdf file at the [location](https://www.stat.berkeley.edu/~ryantibs/statlearn-s23/lectures/resolvents.pdf) will need to be updated.